### PR TITLE
Gatekeep Command

### DIFF
--- a/src/commands/index.js
+++ b/src/commands/index.js
@@ -18,13 +18,14 @@ const patpat = require(`./fun/patpat`);
 // moderation commands
 const ban = require(`./moderation/ban`);
 const eat = require(`./moderation/eat`);
-const welcomeEdit = require(`./moderation/welcomeEdit`);
+const gatekeep = require(`./moderation/gatekeep`);
 const kick = require(`./moderation/kick`);
 const listen = require(`./moderation/listen`);
 const mute = require(`./moderation/mute`);
 const prune = require(`./moderation/prune`);
 const roleEmoji = require(`./moderation/roleEmoji`);
 const serverClock = require(`./moderation/serverClock`);
+const welcomeEdit = require(`./moderation/welcomeEdit`);
 
 // Prefix
 const PREFIX = process.env.PREFIX;
@@ -48,6 +49,7 @@ const commands = {
   eat,
   patpat,
   clock: serverClock,
+  gatekeep,
 };
 
 module.exports = async (msg, store) => {

--- a/src/commands/moderation/gatekeep.js
+++ b/src/commands/moderation/gatekeep.js
@@ -1,0 +1,142 @@
+const Discord = require(`discord.js`);
+const ServerInfo = require(`../../database/models/dbdiscordserverinfo`);
+const { serverCache, logger } = require(`../../utils/botUtils`);
+const { guildDataUpdated, guildsSelector } = require(`../../redux/guildsSlice`);
+
+module.exports = async (msg, args, store) => {
+  if (msg.member.hasPermission([`MANAGE_ROLES`])) {
+    logger.info(
+      `${msg.author.username} can add roles and remove roles from Discord Server: ${msg.guild}`
+    );
+
+    // should double check if there's existing gatekeep info
+    // should give user more options later
+
+    msg.channel.send(
+      `${msg.author}, what channel would you like to keep an eye on? Type in the channel name\n(Don't forget to end your welcome message with j.end)\nIf you would like to exit without making changes, type j.exit`
+    );
+
+    let filter = (m) => !m.author.bot;
+    let collector = new Discord.MessageCollector(msg.channel, filter);
+
+    collector.on(`collect`, async (m, col) => {
+      logger.info(
+        `\nChannel: ${msg.channel.name}\nUser: ${m.author.tag}\nMessage: ${m.content}`
+      );
+
+      if (
+        msg.author.id === m.author.id &&
+        m.content.startsWith(`<#`) &&
+        m.content.includes(`j.end`)
+      ) {
+        let channel;
+        const regex = /([<#\d>])+/;
+        channel = m.content.match(regex);
+
+        logger.info({ channel });
+
+        if (channel[0].includes(`<#`)) {
+          channel = channel[0].slice(2, channel[0].length - 1);
+          // note to revamp later
+        } else {
+          logger.error(`Cannot find channel`);
+          msg.channel.send(
+            `${msg.author}, you've entered an incorrect channel name. Please enter a valid channel.`
+          );
+          return;
+        }
+
+        let guildInfo = await ServerInfo.findOne({
+          server_id: msg.channel.guild.id,
+        });
+
+        guildInfo.gatekeeper.channel_ID = channel;
+        await guildInfo.save();
+        store.dispatch(guildDataUpdated(serverCache(guildInfo)));
+
+        logger.info(`Channel has been collected: ${channel}`);
+        msg.channel.send(
+          `${msg.author}, Please enter what the passcode should be. Type j.messageEnd when you're done`
+        );
+      }
+
+      if (msg.author.id === m.author.id && m.content.includes(`j.messageEnd`)) {
+        let passcode = m.content
+          .slice()
+          .replace(/( j.messageEnd|j.messageEnd)/g, ``);
+        logger.info(`\n** passcode has been collected **\n ${passcode}`);
+
+        let guildInfo = await ServerInfo.findOne({
+          server_id: msg.channel.guild.id,
+        });
+
+        guildInfo.gatekeeper.passcode = passcode;
+
+        await guildInfo.save();
+
+        store.dispatch(guildDataUpdated(serverCache(guildInfo)));
+        msg.channel.send(
+          `${msg.author}, Please let me know what role I should add. Type j.roleCollect when you're done`
+        );
+      }
+
+      if (
+        msg.author.id === m.author.id &&
+        m.content.includes(`j.roleCollect`)
+      ) {
+        const regex = /([(<@&|:)\d>])+/g;
+        let roleMapping = m.content.match(regex);
+
+        logger.info(roleMapping);
+
+        let roleID = roleMapping[0].slice(3, roleMapping[0].length - 1);
+
+        // do validation checks
+        if (roleID) {
+          // do a role ID check
+        } else {
+          logger.error(`Invalid input for roleID`);
+          msg.channel.send(
+            `${msg.author}, the emoji entered was not recognized.\nPlease follow this format: @role j.roleCollect`
+          );
+          return;
+        }
+
+        logger.info(
+          `\nThis is the Role ID Mapping: ${roleMapping}\nThis is the Role ID: ${roleID}`
+        );
+
+        let guildInfo = await ServerInfo.findOne({
+          server_id: msg.channel.guild.id,
+        });
+
+        guildInfo.gatekeeper.role_bind = roleID;
+
+        try {
+          await guildInfo.save();
+          store.dispatch(guildDataUpdated(serverCache(guildInfo)));
+          logger.info(`We've saved the role ID to watch into the Database`);
+          msg.channel.send(
+            `${msg.author}, Thanks! I saved all the information I needed`
+          );
+        } catch (err) {
+          logger.error(err);
+        }
+      }
+
+      if (msg.author.id === m.author.id && m.content.startsWith(`j.exit`)) {
+        msg.channel.send(
+          `${msg.author}, I made no changes as you've requested`
+        );
+        collector.stop();
+      }
+    });
+  } else {
+    logger.warn(
+      `${msg.author.username} from ${msg.guild} cannot add a gatekeeper`
+    );
+    return msg.channel.send(
+      `${msg.author.username} does not have the authority to edit the role emoji mappings`
+    );
+  }
+};

--- a/src/database/models/dbdiscordserverinfo.js
+++ b/src/database/models/dbdiscordserverinfo.js
@@ -31,7 +31,8 @@ const DiscordServerInfoSchema = new mongoose.Schema({
   gatekeeper: {
     channel_ID: String,
     passcode: String,
-    role_bind: String,
+    role_watch: String,
+    role_add: String,
   },
   WelcomeMessage: {
     MessageInfo: {

--- a/src/database/models/dbdiscordserverinfo.js
+++ b/src/database/models/dbdiscordserverinfo.js
@@ -28,6 +28,11 @@ const DiscordServerInfoSchema = new mongoose.Schema({
       type: [mongoose.Schema.Types.Mixed],
     },
   },
+  gatekeeper: {
+    channel_ID: String,
+    passcode: String,
+    role_bind: String,
+  },
   WelcomeMessage: {
     MessageInfo: {
       type: String,

--- a/src/index.js
+++ b/src/index.js
@@ -253,10 +253,12 @@ client.on(`message`, async (message) => {
 
   if (specialMessage === `good morning jeet!`) {
     message.channel.send(`Good Morning ${message.author.username}`);
+    return;
   }
 
   if (specialMessage === `jeet i love you!`) {
     message.channel.send(`I love you too, ${message.author.username}`);
+    return;
   }
 
   if (
@@ -274,6 +276,8 @@ client.on(`message`, async (message) => {
     message.channel.send(
       `${message.author.username}, I sent a response to terminal`
     );
+
+    return;
   }
 
   let guildInfo = guildsSelector.selectById(
@@ -281,26 +285,72 @@ client.on(`message`, async (message) => {
     message.channel.guild.id
   );
 
-  member = message.guild.members.cache.find(
-    (member) => member.id === message.author.id
-  );
-  role = message.guild.roles.cache.find(
-    (role) => role.id === guildInfo.EatRole
-  );
+  if (guildInfo.EatRole) {
+    let member = message.guild.members.cache.find(
+      (member) => member.id === message.author.id
+    );
+    let role = message.guild.roles.cache.find(
+      (role) => role.id === guildInfo.EatRole
+    );
 
-  if (member && role) {
-    if (member._roles.includes(role.id)) {
-      logger.info(
-        `${message.author.username} in ${message.channel.guild.name} has a chance to get their messages eaten by Ffej.`
+    if (member && role) {
+      if (member._roles.includes(role.id)) {
+        logger.info(
+          `${message.author.username} in ${message.channel.guild.name} has a chance to get their messages eaten by Ffej.`
+        );
+        let chance = Math.floor(Math.random() * 100) + 1;
+
+        if (chance > 0 && chance <= 50) {
+          message
+            .delete()
+            .then((msg) =>
+              logger.info(
+                `Ffej has deleted message from ${msg.author.username} in Discord Server: ${msg.channel.guild.name}`
+              )
+            )
+            .catch((err) => logger.error(err));
+        }
+      }
+    }
+  }
+
+  // check if the guild has gatekeeper info
+  if (guildInfo.gatekeeper) {
+    // get the channel info
+    if (message.channel.id == guildInfo.gatekeeper.channel_ID) {
+      let roleWatch = undefined;
+      roleWatch = message.guild.roles.cache.find(
+        (role) => role.id === guildInfo.gatekeeper.role_watch
       );
-      let chance = Math.floor(Math.random() * 100) + 1;
 
-      if (chance > 0 && chance <= 50) {
+      if (roleWatch) {
+        // test for the passcode found in the channel
+        if (message.content.includes(guildInfo.gatekeeper.passcode)) {
+          let roleAdd = message.guild.roles.cache.find(
+            (role) => role.id === guildInfo.gatekeeper.role_add
+          );
+
+          let member = message.guild.members.cache.find(
+            (member) => member.id === message.author.id
+          );
+
+          await member.roles.add(roleAdd);
+
+          message
+            .delete()
+            .then((msg) =>
+              logger.info(
+                `Jeet has allowed ${msg.author.username} through the gate in Discord Server: ${msg.channel.guild.name}`
+              )
+            )
+            .catch((err) => logger.error(err));
+        }
+      } else {
         message
           .delete()
           .then((msg) =>
             logger.info(
-              `Ffej has deleted message from ${msg.author.username} in Discord Server: ${msg.channel.guild.name}`
+              `Jeet has deleted ${msg.author.username}'s message in Discord Server: ${msg.channel.guild.name} and has denied access`
             )
           )
           .catch((err) => logger.error(err));

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,7 @@ const ServerInfo = require(`./database/models/dbdiscordserverinfo`);
 
 // Handlers
 const commandHandler = require(`./commands`);
+// need an event handler here
 
 // cooldowns to fix later
 const cooldowns = new Discord.Collection();
@@ -237,6 +238,11 @@ client.on(`messageReactionAdd`, async (reaction, user) => {
       applyRole(guildInfo.RoleReactions.RoleMappings);
     }
   }
+});
+
+client.on(`messageReactionRemove`, async (reaction, user) => {
+  // need function to remove role when unclick
+  // if there is a gatekeep role bind to it, check for it.
 });
 
 // Special Messages and EatRole Handler


### PR DESCRIPTION
## Adding a way for moderators to ensure that their users read their rules.

1. Moderator types out **j.gatekeep**
2. Enters in the following data through Jeetbot prompts: 
    - channel
    - passcode
    - RoleToWatch
    - RoleToAdd
3. The bot will then double-check for any users who are typing in the **channel** and has the **RoleToWatch**.
4. Once the user enters in the **passcode** prompt, the bot adds the **RoleToAdd** get another role added that allows them to see other channels in the discord server.